### PR TITLE
Feature/select day in Calendar

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,9 @@ class MyApp extends StatelessWidget {
                 fontSize: 18,
                 fontWeight: FontWeight.bold,
               ),
+              bodySmall: const TextStyle(
+                color: Colors.white,
+              ),
             ),
         appBarTheme: ThemeData.light().appBarTheme.copyWith(
               titleTextStyle: const TextStyle(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,11 +68,11 @@ class _MyHomePageState extends State<MyHomePage> {
     }).toList();
   }
 
-  void _addNewTransaction(String title, int amount) {
+  void _addNewTransaction(String title, int amount, DateTime chosenDate) {
     final newTransaction = Transaction(
       title: title,
       amount: amount,
-      date: DateTime.now(),
+      date: chosenDate,
       id: DateTime.now().toString(),
     );
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:intl/date_symbol_data_local.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 
 import './widgets/transaction_list.dart';
 import './models/transaction.dart';
@@ -7,7 +7,6 @@ import './widgets/chart.dart';
 import './widgets/new_transaction.dart';
 
 void main() async {
-  await initializeDateFormatting('ja_JP');
   runApp(const MyApp());
 }
 
@@ -40,6 +39,10 @@ class MyApp extends StatelessWidget {
             ),
       ),
       home: const MyHomePage(),
+      localizationsDelegates:const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,12 @@ class MyApp extends StatelessWidget {
                 fontSize: 18,
                 fontWeight: FontWeight.bold,
               ),
+              titleSmall: const TextStyle(
+                color: Colors.grey,
+                fontFamily: 'OpenSans',
+                fontSize: 15,
+                fontWeight: FontWeight.bold,
+              ),
               bodySmall: const TextStyle(
                 color: Colors.white,
               ),

--- a/lib/widgets/chart.dart
+++ b/lib/widgets/chart.dart
@@ -24,7 +24,7 @@ class Chart extends StatelessWidget {
         }
       }
       return {'day': DateFormat.E('ja').format(weekDay), 'amount': totalSum};
-    });
+    }).reversed.toList();
   }
 
   double get totalSpending {

--- a/lib/widgets/chart_bar.dart
+++ b/lib/widgets/chart_bar.dart
@@ -16,7 +16,9 @@ class ChartBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        FittedBox(child: Text('¥${spendingAmount.toString()}')),
+        SizedBox(
+            height: 20,
+            child: FittedBox(child: Text('¥${spendingAmount.toString()}'))),
         const SizedBox(
           height: 4,
         ),

--- a/lib/widgets/new_transaction.dart
+++ b/lib/widgets/new_transaction.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 class NewTransaction extends StatefulWidget {
   const NewTransaction({Key? key, required this.addTransaction})
@@ -11,8 +12,8 @@ class NewTransaction extends StatefulWidget {
 
 class _NewTransactionState extends State<NewTransaction> {
   final _titleController = TextEditingController();
-
   final _amountController = TextEditingController();
+  DateTime? _selectedDate;
 
   void _submitData() {
     final enteredTitle = _titleController.text;
@@ -28,6 +29,21 @@ class _NewTransactionState extends State<NewTransaction> {
     );
 
     Navigator.of(context).pop();
+  }
+
+  void _presentDatePicker() async {
+    DateTime? pickedDate = await showDatePicker(
+      context: context,
+      initialDate: DateTime.now(),
+      firstDate: DateTime(2020),
+      lastDate: DateTime.now(),
+    );
+    if (pickedDate == null) {
+      return;
+    }
+    setState(() {
+      _selectedDate = pickedDate;
+    });
   }
 
   @override
@@ -56,9 +72,11 @@ class _NewTransactionState extends State<NewTransaction> {
             height: 70,
             child: Row(
               children: [
-                const Text('日付が未選択です！'),
+                Expanded(
+                  child: Text(setDateText(_selectedDate)),
+                ),
                 TextButton(
-                  onPressed: () {},
+                  onPressed: _presentDatePicker,
                   child: const Text(
                     '日付を選択',
                     style: TextStyle(
@@ -79,5 +97,14 @@ class _NewTransactionState extends State<NewTransaction> {
         ],
       ),
     );
+  }
+}
+
+// _selectedDateの状態に応じて表示テキストを変更
+String setDateText(DateTime? selectedDate) {
+  if (selectedDate == null) {
+    return '日付が選択されていません';
+  } else {
+    return '日付：${DateFormat.yMMMd('ja').format(selectedDate)}';
   }
 }

--- a/lib/widgets/new_transaction.dart
+++ b/lib/widgets/new_transaction.dart
@@ -16,6 +16,10 @@ class _NewTransactionState extends State<NewTransaction> {
   DateTime? _selectedDate;
 
   void _submitData() {
+    if (_amountController.text.isEmpty) {
+      return;
+    }
+
     final enteredTitle = _titleController.text;
     final enteredAmount = int.parse(_amountController.text);
 

--- a/lib/widgets/new_transaction.dart
+++ b/lib/widgets/new_transaction.dart
@@ -32,8 +32,8 @@ class _NewTransactionState extends State<NewTransaction> {
 
   @override
   Widget build(BuildContext context) {
-    return  Container(
-      margin:const EdgeInsets.all(8.0),
+    return Container(
+      margin: const EdgeInsets.all(8.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
@@ -52,7 +52,24 @@ class _NewTransactionState extends State<NewTransaction> {
             keyboardType: const TextInputType.numberWithOptions(decimal: true),
             onSubmitted: (_) => submitData(),
           ),
-          TextButton(
+          SizedBox(
+            height: 70,
+            child: Row(
+              children: [
+                const Text('日付が未選択です！'),
+                TextButton(
+                  onPressed: () {},
+                  child: const Text(
+                    '日付を選択',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          ElevatedButton(
             onPressed: submitData,
             child: const Text('登録'),
           )

--- a/lib/widgets/new_transaction.dart
+++ b/lib/widgets/new_transaction.dart
@@ -19,7 +19,7 @@ class _NewTransactionState extends State<NewTransaction> {
     final enteredTitle = _titleController.text;
     final enteredAmount = int.parse(_amountController.text);
 
-    if (enteredTitle.isEmpty || enteredAmount <= 0) {
+    if (enteredTitle.isEmpty || enteredAmount <= 0 || _selectedDate == null) {
       return;
     }
 

--- a/lib/widgets/new_transaction.dart
+++ b/lib/widgets/new_transaction.dart
@@ -10,13 +10,13 @@ class NewTransaction extends StatefulWidget {
 }
 
 class _NewTransactionState extends State<NewTransaction> {
-  final titleController = TextEditingController();
+  final _titleController = TextEditingController();
 
-  final amountController = TextEditingController();
+  final _amountController = TextEditingController();
 
   void _submitData() {
-    final enteredTitle = titleController.text;
-    final enteredAmount = int.parse(amountController.text);
+    final enteredTitle = _titleController.text;
+    final enteredAmount = int.parse(_amountController.text);
 
     if (enteredTitle.isEmpty || enteredAmount <= 0) {
       return;
@@ -41,14 +41,14 @@ class _NewTransactionState extends State<NewTransaction> {
             decoration: const InputDecoration(
               label: Text('使用目的'),
             ),
-            controller: titleController,
+            controller: _titleController,
             onSubmitted: (_) => _submitData(),
           ),
           TextField(
             decoration: const InputDecoration(
               label: Text('金額'),
             ),
-            controller: amountController,
+            controller: _amountController,
             keyboardType: const TextInputType.numberWithOptions(decimal: true),
             onSubmitted: (_) => _submitData(),
           ),
@@ -71,7 +71,10 @@ class _NewTransactionState extends State<NewTransaction> {
           ),
           ElevatedButton(
             onPressed: _submitData,
-            child: Text('登録', style: Theme.of(context).textTheme.bodySmall,),
+            child: Text(
+              '登録',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
           )
         ],
       ),

--- a/lib/widgets/new_transaction.dart
+++ b/lib/widgets/new_transaction.dart
@@ -71,7 +71,7 @@ class _NewTransactionState extends State<NewTransaction> {
           ),
           ElevatedButton(
             onPressed: submitData,
-            child: const Text('登録'),
+            child: Text('登録', style: Theme.of(context).textTheme.bodySmall,),
           )
         ],
       ),

--- a/lib/widgets/new_transaction.dart
+++ b/lib/widgets/new_transaction.dart
@@ -30,6 +30,7 @@ class _NewTransactionState extends State<NewTransaction> {
     widget.addTransaction(
       enteredTitle,
       enteredAmount,
+      _selectedDate
     );
 
     Navigator.of(context).pop();

--- a/lib/widgets/new_transaction.dart
+++ b/lib/widgets/new_transaction.dart
@@ -14,7 +14,7 @@ class _NewTransactionState extends State<NewTransaction> {
 
   final amountController = TextEditingController();
 
-  void submitData() {
+  void _submitData() {
     final enteredTitle = titleController.text;
     final enteredAmount = int.parse(amountController.text);
 
@@ -42,7 +42,7 @@ class _NewTransactionState extends State<NewTransaction> {
               label: Text('使用目的'),
             ),
             controller: titleController,
-            onSubmitted: (_) => submitData(),
+            onSubmitted: (_) => _submitData(),
           ),
           TextField(
             decoration: const InputDecoration(
@@ -50,7 +50,7 @@ class _NewTransactionState extends State<NewTransaction> {
             ),
             controller: amountController,
             keyboardType: const TextInputType.numberWithOptions(decimal: true),
-            onSubmitted: (_) => submitData(),
+            onSubmitted: (_) => _submitData(),
           ),
           SizedBox(
             height: 70,
@@ -70,7 +70,7 @@ class _NewTransactionState extends State<NewTransaction> {
             ),
           ),
           ElevatedButton(
-            onPressed: submitData,
+            onPressed: _submitData,
             child: Text('登録', style: Theme.of(context).textTheme.bodySmall,),
           )
         ],

--- a/lib/widgets/new_transaction.dart
+++ b/lib/widgets/new_transaction.dart
@@ -33,6 +33,7 @@ class _NewTransactionState extends State<NewTransaction> {
 
   void _presentDatePicker() async {
     DateTime? pickedDate = await showDatePicker(
+      locale: const Locale("ja"),
       context: context,
       initialDate: DateTime.now(),
       firstDate: DateTime(2020),

--- a/lib/widgets/transaction_list.dart
+++ b/lib/widgets/transaction_list.dart
@@ -25,47 +25,24 @@ class TransactionList extends StatelessWidget {
         : ListView.builder(
             itemBuilder: ((context, index) {
               return Card(
-                child: Row(
-                  children: [
-                    Container(
-                      margin: const EdgeInsets.symmetric(
-                        vertical: 10,
-                        horizontal: 15,
-                      ),
-                      padding: const EdgeInsets.all(10),
-                      decoration: BoxDecoration(
-                        border: Border.all(
-                          color: Theme.of(context).primaryColor,
-                          width: 2,
-                        ),
-                      ),
-                      child: Text(
-                        '${transactions[index].amount}円',
-                        style: TextStyle(
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
-                          color: Theme.of(context).primaryColor,
-                        ),
-                      ),
+                elevation: 5.0,
+                margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 5),
+                child: ListTile(
+                  leading: CircleAvatar(
+                    radius: 30,
+                    child: Padding(
+                      padding: const EdgeInsets.all(6.0),
+                      child: FittedBox(
+                          child: Text('${transactions[index].amount}円')),
                     ),
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          transactions[index].title,
-                          style: Theme.of(context).textTheme.titleMedium,
-                        ),
-                        Text(
-                          DateFormat.yMMMd('ja')
-                              .format(transactions[index].date),
-                          style: const TextStyle(
-                            fontSize: 12,
-                            color: Colors.grey,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
+                  ),
+                  title: Text(
+                    transactions[index].title,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  subtitle: Text(
+                    DateFormat.yMMMd('ja').format(transactions[index].date),
+                  ),
                 ),
               );
             }),

--- a/lib/widgets/transaction_list.dart
+++ b/lib/widgets/transaction_list.dart
@@ -42,6 +42,7 @@ class TransactionList extends StatelessWidget {
                   ),
                   subtitle: Text(
                     DateFormat.yMMMd('ja').format(transactions[index].date),
+                    style: Theme.of(context).textTheme.titleSmall,
                   ),
                 ),
               );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,6 +69,11 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
 
   # The following adds the Cupertino Icons font to your application.
@@ -52,7 +54,7 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-
+  generate: true
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
### トランザクションの日付を選択可能に
- これまでは、DateTime.now()で現在時刻を設定していたが、カレンダーから選択可能に修正
- レイアウトの修正
  - 1週間のトランザクションを逆順に修正
- バグの修正
  - 料金未入力時
  - レイアウトのズレ（Chartの長さ）

<img src='https://user-images.githubusercontent.com/89247188/176197436-4160afe2-c904-4592-98bc-351b4435a7dc.png' width=50%>
 